### PR TITLE
ISSUE-50: Add Django 52 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,16 +18,16 @@ jobs:
         python: ["3.8", "3.9", "3.10", "3.11"]
         django: ["3.2.16", "4.0.8", "4.1.4", "5.0.1"]
         exclude:
-        # Excludes Python 3.11 for Django < 4.1
-        - python: "3.11"
-          django: "3.2.16"
-        - python: "3.11"
-          django: "4.0.8"
-        # Django 5.0 requires Python 3.10 or higher
-        - python: "3.8"
-          django: "5.0.1"
-        - python: "3.9"
-          django: "5.0.1"
+          # Excludes Python 3.11 for Django < 4.1
+          - python: "3.11"
+            django: "3.2.16"
+          - python: "3.11"
+            django: "4.0.8"
+          # Django 5.0 requires Python 3.10 or higher
+          - python: "3.8"
+            django: "5.0.1"
+          - python: "3.9"
+            django: "5.0.1"
 
     services:
       postgres:
@@ -59,40 +59,112 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
-    - uses: pre-commit/action@v3.0.0
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3.0.0
 
   publish:
     if: startsWith(github.event.ref, 'refs/tags')
     name: publish
     needs: pytest
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/django-reactive
+    permissions:
+      id-token: write # IMPORTANT: mandatory for trusted publishing
+
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
           architecture: x64
-      - run: pip install --upgrade pip
-      - run: pip install poetry
-      - run: poetry build
-      - uses: pypa/gh-action-pypi-publish@master
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+      - name: Build package
+        run: poetry build
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.pypi_password_test }}
-          repository_url: https://test.pypi.org/legacy/
-      - uses: pypa/gh-action-pypi-publish@master
+          verbose: true
+
+  publish-to-testpypi:
+    if: startsWith(github.event.ref, 'refs/tags')
+    name: Publish to TestPyPI
+    needs: pytest
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/django-reactive
+    permissions:
+      id-token: write # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+      - uses: actions/checkout@v4
         with:
-          password: ${{ secrets.pypi_password }}
-      - uses: actions/create-release@v1
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          architecture: x64
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+      - name: Build package
+        run: poetry build
+      - name: Publish distribution to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          verbose: true
+
+  github-release:
+    name: Create GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write # IMPORTANT: mandatory for sigstore
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+      - name: Build package
+        run: poetry build
+      - name: Sign the dists with Sigstore
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        with:
+          inputs: >-
+            ./dist/*.tar.gz
+            ./dist/*.whl
+      - name: Create GitHub Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          body: |
-            Changes:
-            - ...
-            - ...
-          draft: true
-          prerelease: false
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create
+          "$GITHUB_REF_NAME"
+          --repo "$GITHUB_REPOSITORY"
+          --title "$GITHUB_REF_NAME"
+          --notes "Release $GITHUB_REF_NAME"
+      - name: Upload artifact signatures to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release upload
+          "$GITHUB_REF_NAME" dist/**
+          --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,13 +73,11 @@ jobs:
       url: https://pypi.org/p/django-reactive
     permissions:
       id-token: write # IMPORTANT: mandatory for trusted publishing
+      contents: write # IMPORTANT: mandatory for making GitHub Releases
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
           architecture: x64
@@ -87,84 +85,24 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install poetry
-      - name: Build package
-        run: poetry build
-      - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          verbose: true
-
-  publish-to-testpypi:
-    if: startsWith(github.event.ref, 'refs/tags')
-    name: Publish to TestPyPI
-    needs: pytest
-    runs-on: ubuntu-latest
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/django-reactive
-    permissions:
-      id-token: write # IMPORTANT: mandatory for trusted publishing
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-          architecture: x64
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install poetry
-      - name: Build package
-        run: poetry build
-      - name: Publish distribution to TestPyPI
+          poetry build
+      - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-          verbose: true
-
-  github-release:
-    name: Create GitHub Release
-    needs: publish
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write # IMPORTANT: mandatory for making GitHub Releases
-      id-token: write # IMPORTANT: mandatory for sigstore
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install poetry
-      - name: Build package
-        run: poetry build
-      - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v3.0.0
-        with:
-          inputs: >-
-            ./dist/*.tar.gz
-            ./dist/*.whl
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: >-
-          gh release create
-          "$GITHUB_REF_NAME"
-          --repo "$GITHUB_REPOSITORY"
-          --title "$GITHUB_REF_NAME"
-          --notes "Release $GITHUB_REF_NAME"
-      - name: Upload artifact signatures to GitHub Release
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$GITHUB_REF_NAME" \
+            --notes "Release $GITHUB_REF_NAME"
+      - name: Upload artifacts to release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: >-
-          gh release upload
-          "$GITHUB_REF_NAME" dist/**
-          --repo "$GITHUB_REPOSITORY"
+        run: |
+          gh release upload "$GITHUB_REF_NAME" dist/* \
+            --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,18 @@ jobs:
       fail-fast: false
       matrix:
         python: ["3.8", "3.9", "3.10", "3.11"]
-        django: ["3.2.16", "4.0.8", "4.1.4" ]
+        django: ["3.2.16", "4.0.8", "4.1.4", "5.0.1"]
         exclude:
         # Excludes Python 3.11 for Django < 4.1
         - python: "3.11"
           django: "3.2.16"
         - python: "3.11"
           django: "4.0.8"
+        # Django 5.0 requires Python 3.10 or higher
+        - python: "3.8"
+          django: "5.0.1"
+        - python: "3.9"
+          django: "5.0.1"
 
     services:
       postgres:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ keywords = ["django",
 python = ">=3.8.1,<4"
 jsonschema = "^3.0||^4.0"
 psycopg2-binary = "^2.7||^3.0"
-django = "^3.2||^4.0"
+django = "^3.2||^4.0||^5.0"
 
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,9 @@ keywords = ["django",
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4"
-jsonschema = "^3.0||^4.0"
-psycopg2-binary = "^2.7||^3.0"
-django = "^3.2||^4.0||^5.0"
+jsonschema = ">=3.0,<5"
+psycopg2-binary = ">=2.7,<4"
+django = ">=3.2"
 
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
1.Supports all Django future versions >3.2
2. New recommend method of Publishing added-
https://github.com/marketplace/actions/pypi-publish#trusted-publishing
https://docs.pypi.org/trusted-publishers/adding-a-publisher/